### PR TITLE
Changes related to use plugins on hosts that use byte/integer color bit depth.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 openfx-supportext
 =================
 
+
+
 Extensions for the OpenFX Support library

--- a/ofxsMaskMix.h
+++ b/ofxsMaskMix.h
@@ -344,9 +344,6 @@ ofxsPremultMaskMixPix(const float unpPix[4], //!< interpolated unpremultiplied p
     float tmpPix[nComponents];
 
     ofxsPremult<PIX, nComponents, maxValue>(unpPix, tmpPix, premult, premultChannel);
-    //for (int c = 0; c < nComponents; ++c) {
-        //tmpPix[c] *= maxValue;
-    //}
 	ofxsMaskMixPix<PIX, nComponents, maxValue, masked>(tmpPix, x, y, srcPix, domask, maskImg, mix, maskInvert, dstPix);
 }
 

--- a/ofxsMaskMix.h
+++ b/ofxsMaskMix.h
@@ -192,16 +192,16 @@ ofxsUnPremult(const PIX *srcPix,
         unpPix[0] = 0.f;
         unpPix[1] = 0.f;
         unpPix[2] = 0.f;
-        unpPix[3] = srcPix[0] / (float)maxValue;
+		unpPix[3] = (float)srcPix[0] / (float)maxValue;
 
         return;
     }
 
     if ( !premult || (nComponents == 3) || (srcPix[3] <= 0.) ) {
-        unpPix[0] = srcPix[0] / (float)maxValue;
-        unpPix[1] = srcPix[1] / (float)maxValue;
-        unpPix[2] = srcPix[2] / (float)maxValue;
-        unpPix[3] = (nComponents == 4) ? (srcPix[3] / (float)maxValue) : 1.0f;
+		unpPix[0] = (float)srcPix[0] / (float)maxValue;
+		unpPix[1] = (float)srcPix[1] / (float)maxValue;
+		unpPix[2] = (float)srcPix[2] / (float)maxValue;
+		unpPix[3] = (nComponents == 4) ? ((float)srcPix[3] / (float)maxValue) : 1.0f;
 
         return;
     }
@@ -210,15 +210,15 @@ ofxsUnPremult(const PIX *srcPix,
     const float fltmin = std::numeric_limits<float>::min();
     PIX alpha = srcPix[3];
     if ( alpha > (PIX)(fltmin * maxValue) ) {
-        unpPix[0] = srcPix[0] / alpha;
-        unpPix[1] = srcPix[1] / alpha;
-        unpPix[2] = srcPix[2] / alpha;
+		unpPix[0] = (float)srcPix[0] / (float)alpha;
+		unpPix[1] = (float)srcPix[1] / (float)alpha;
+		unpPix[2] = (float)srcPix[2] / (float)alpha;
     } else {
-        unpPix[0] = srcPix[0] / (float)maxValue;
-        unpPix[1] = srcPix[1] / (float)maxValue;
-        unpPix[2] = srcPix[2] / (float)maxValue;
+		unpPix[0] = (float)srcPix[0] / (float)maxValue;
+		unpPix[1] = (float)srcPix[1] / (float)maxValue;
+		unpPix[2] = (float)srcPix[2] / (float)maxValue;
     }
-    unpPix[3] = srcPix[3] / (float)maxValue;
+	unpPix[3] = (float)srcPix[3] / (float)maxValue;
 }
 
 // premultiply and denormalize in [0, maxValue]

--- a/ofxsMaskMix.h
+++ b/ofxsMaskMix.h
@@ -301,7 +301,11 @@ ofxsMaskMixPix(const float *tmpPix, //!< interpolated pixel
             if (maskPix == 0) {
                 maskScale = maskInvert ? 1.f : 0.f;
             } else {
-                maskScale = *maskPix / float(maxValue);
+				if (maskImg->getPixelComponents() == ePixelComponentAlpha)
+					maskScale = *maskPix / float(maxValue);
+				else
+					maskScale = *(maskPix + 3) / float(maxValue);
+
                 if (maskInvert) {
                     maskScale = 1.f - maskScale;
                 }

--- a/ofxsMaskMix.h
+++ b/ofxsMaskMix.h
@@ -344,10 +344,10 @@ ofxsPremultMaskMixPix(const float unpPix[4], //!< interpolated unpremultiplied p
     float tmpPix[nComponents];
 
     ofxsPremult<PIX, nComponents, maxValue>(unpPix, tmpPix, premult, premultChannel);
-    for (int c = 0; c < nComponents; ++c) {
-        tmpPix[c] *= maxValue;
-    }
-    ofxsMaskMixPix<PIX, nComponents, maxValue, masked>(tmpPix, x, y, srcPix, domask, maskImg, mix, maskInvert, dstPix);
+    //for (int c = 0; c < nComponents; ++c) {
+        //tmpPix[c] *= maxValue;
+    //}
+	ofxsMaskMixPix<PIX, nComponents, maxValue, masked>(tmpPix, x, y, srcPix, domask, maskImg, mix, maskInvert, dstPix);
 }
 
 // tmpPix is not normalized, it is within [0,maxValue]


### PR DESCRIPTION
I made changes that allows hosts with byte/integer color bit depth to use plugins. It generally contains 3 fixes:
- allows to use RGBA image as mask image,
-  fxsUnPremult wrongly calculated pixel color for byte/integer color bit depth,
-  ofxsPremult multiplied maxValue twice - so float bit depth was not affected.
