### PR TITLE
Add support for EGL loading

### DIFF
--- a/glad/gladegl.cpp
+++ b/glad/gladegl.cpp
@@ -1,0 +1,75 @@
+#if !defined(__APPLE__) && !defined(__HAIKU__) \
+  && !defined(_WIN32) && !defined(__CYGWIN__)
+
+#include <glad/glad.h>
+#include <EGL/egl.h>
+#include <dlfcn.h>
+
+static void* libEGL;
+
+typedef void* (APIENTRYP PFNEGLGETPROCADDRESSPROC_PRIVATE)(const char*);
+static PFNEGLGETPROCADDRESSPROC_PRIVATE gladGetProcAddressPtr;
+
+static
+int open_egl(void) {
+    static const char *NAMES[] = {"libEGL.so.1", "libEGL.so"};
+
+    unsigned int index = 0;
+    for(index = 0; index < (sizeof(NAMES) / sizeof(NAMES[0])); index++) {
+        libEGL = dlopen(NAMES[index], RTLD_NOW | RTLD_GLOBAL);
+
+        if(libEGL != NULL) {
+            gladGetProcAddressPtr = (PFNEGLGETPROCADDRESSPROC_PRIVATE)dlsym(libEGL,
+                "eglGetProcAddress");
+            return gladGetProcAddressPtr != NULL;
+        }
+    }
+
+    return 0;
+}
+
+static
+void close_egl(void) {
+    if(libEGL != NULL) {
+        dlclose(libEGL);
+        libEGL = NULL;
+    }
+}
+
+static
+void* get_proc(const char *namez) {
+    void* result = NULL;
+    if(libEGL == NULL) return NULL;
+
+    if(gladGetProcAddressPtr != NULL) {
+        result = gladGetProcAddressPtr(namez);
+    }
+    if(result == NULL) {
+        result = dlsym(libEGL, namez);
+    }
+
+    return result;
+}
+
+int gladLoadEGL(void) {
+    int status = 0;
+    PFNEGLBINDAPIPROC bindAPI = NULL;
+
+    if(open_egl()) {
+        bindAPI = get_proc("eglBindAPI");
+        if (bindAPI != NULL && bindAPI(EGL_OPENGL_API)) {
+            status = gladLoadGLLoader(&get_proc);
+        }
+        close_egl();
+    }
+
+    return status;
+}
+
+#else
+
+int gladLoadEGL(void) {
+    return 0;
+}
+
+#endif

--- a/glad/gladegl.h
+++ b/glad/gladegl.h
@@ -1,0 +1,1 @@
+GLAPI int gladLoadEGL(void);

--- a/ofxsOGLUtilities.cpp
+++ b/ofxsOGLUtilities.cpp
@@ -41,6 +41,9 @@ static bool g_glLoaded = false;
 
 extern "C" {
 extern int gladLoadGL(void);
+#if !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__APPLE__) && !defined(__HAIKU__)
+extern int gladLoadEGL(void);
+#endif
 struct gladGLversionStruct
 {
     int major;
@@ -171,7 +174,18 @@ ofxsLoadOpenGLOnce()
     // - opengl32.dll was not found, or libGL.so was not found or OpenGL.framework was not found
     // - glGetString does not return a valid version
     // Note: It does NOT check that required extensions and functions have actually been found
+#if !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__APPLE__) && !defined(__HAIKU__)
+    bool glLoaded = false;
+    const char *onWayland = getenv("WAYLAND_DISPLAY");
+    const char *disableWayland = getenv("NATRON_DISABLE_WAYLAND");
+    if (onWayland && onWayland[0] != '\0' && !disableWayland) {
+        glLoaded = gladLoadEGL();
+    } else {
+        glLoaded = gladLoadGL();
+    }
+#else
     bool glLoaded = gladLoadGL();
+#endif
 
     g_glLoaded = glLoaded;
 


### PR DESCRIPTION
Adds GLAD loading for platforms based on EGL that don't support GLX. Required by NatronGitHub/Natron#765.
