### PR TITLE
gladegl.cpp: fixes for C code as cpp

### DIFF
--- a/glad/gladegl.cpp
+++ b/glad/gladegl.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 #if !defined(__APPLE__) && !defined(__HAIKU__) \
   && !defined(_WIN32) && !defined(__CYGWIN__)
 
@@ -51,6 +53,7 @@ void* get_proc(const char *namez) {
     return result;
 }
 
+extern "C"
 int gladLoadEGL(void) {
     int status = 0;
     PFNEGLBINDAPIPROC bindAPI = NULL;
@@ -68,6 +71,7 @@ int gladLoadEGL(void) {
 
 #else
 
+extern "C"
 int gladLoadEGL(void) {
     return 0;
 }


### PR DESCRIPTION
For some reason this file is `.cpp` (and for me compiled with `g++`) but it didn't have the right headers and the rest of the code expected it to export C calls.

Alternatively, we could change the build and make this just C.