### PR TITLE
Fix gladLoadEGL() declaration.

### DIFF
--- a/glad/gladegl.cpp
+++ b/glad/gladegl.cpp
@@ -1,9 +1,11 @@
+#include <glad/gladegl.h>
+
 #if !defined(__APPLE__) && !defined(__HAIKU__) \
   && !defined(_WIN32) && !defined(__CYGWIN__)
 
-#include <glad/glad.h>
 #include <EGL/egl.h>
 #include <dlfcn.h>
+#include <cstddef>
 
 static void* libEGL;
 

--- a/glad/gladegl.h
+++ b/glad/gladegl.h
@@ -1,1 +1,16 @@
+#ifndef __gladegl_h_
+#define __gladegl_h_
+
+#include <glad/glad.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 GLAPI int gladLoadEGL(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif

--- a/ofxsOGLFunctions.h
+++ b/ofxsOGLFunctions.h
@@ -1532,7 +1532,7 @@ typedef void (*PFNGLMULTTRANSPOSEMATRIXFPROC)(const GLfloat* m);
 typedef void (*PFNGLMULTTRANSPOSEMATRIXDPROC)(const GLdouble* m);
 typedef void (*PFNGLBLENDFUNCSEPARATEPROC)(GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha);
 typedef void (*PFNGLMULTIDRAWARRAYSPROC)(GLenum mode, const GLint* first, const GLsizei* count, GLsizei drawcount);
-typedef void (*PFNGLMULTIDRAWELEMENTSPROC)(GLenum mode, const GLsizei* count, GLenum type, const void** indices, GLsizei drawcount);
+typedef void (*PFNGLMULTIDRAWELEMENTSPROC)(GLenum mode, const GLsizei* count, GLenum type, const void*const* indices, GLsizei drawcount);
 typedef void (*PFNGLPOINTPARAMETERFPROC)(GLenum pname, GLfloat param);
 typedef void (*PFNGLPOINTPARAMETERFVPROC)(GLenum pname, const GLfloat* params);
 typedef void (*PFNGLPOINTPARAMETERIPROC)(GLenum pname, GLint param);
@@ -1630,7 +1630,7 @@ typedef void (*PFNGLGETVERTEXATTRIBPOINTERVPROC)(GLuint index, GLenum pname, voi
 typedef GLboolean (*PFNGLISPROGRAMPROC)(GLuint program);
 typedef GLboolean (*PFNGLISSHADERPROC)(GLuint shader);
 typedef void (*PFNGLLINKPROGRAMPROC)(GLuint program);
-typedef void (*PFNGLSHADERSOURCEPROC)(GLuint shader, GLsizei count, const GLchar** string, const GLint* length);
+typedef void (*PFNGLSHADERSOURCEPROC)(GLuint shader, GLsizei count, const GLchar*const* string, const GLint* length);
 typedef void (*PFNGLUSEPROGRAMPROC)(GLuint program);
 typedef void (*PFNGLUNIFORM1FPROC)(GLint location, GLfloat v0);
 typedef void (*PFNGLUNIFORM2FPROC)(GLint location, GLfloat v0, GLfloat v1);

--- a/ofxsOGLUtilities.cpp
+++ b/ofxsOGLUtilities.cpp
@@ -18,6 +18,11 @@
  * along with openfx-supportext.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>
  * ***** END LICENSE BLOCK ***** */
 
+#include <glad/glad.h>
+#if !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__APPLE__) && !defined(__HAIKU__)
+#include <glad/gladegl.h>
+#endif
+
 #include "ofxsOGLUtilities.h"
 
 #include "ofxsOGLFunctions.h"
@@ -38,125 +43,6 @@ typedef OFX::MultiThread::AutoMutexT<tthread::fast_mutex> AutoMutex;
 
 static Mutex g_glLoadOnceMutex;
 static bool g_glLoaded = false;
-
-extern "C" {
-extern int gladLoadGL(void);
-#if !defined(_WIN32) && !defined(__CYGWIN__) && !defined(__APPLE__) && !defined(__HAIKU__)
-extern int gladLoadEGL(void);
-#endif
-struct gladGLversionStruct
-{
-    int major;
-    int minor;
-};
-
-typedef void (* GLADcallback)(const char *name, void *funcptr, int len_args, ...);
-extern void glad_set_pre_callback(GLADcallback);
-extern void glad_set_post_callback(GLADcallback);
-extern gladGLversionStruct GLVersion;
-extern int GLAD_GL_ARB_vertex_buffer_object;
-extern int GLAD_GL_ARB_framebuffer_object;
-extern int GLAD_GL_ARB_pixel_buffer_object;
-extern int GLAD_GL_ARB_vertex_array_object;
-extern int GLAD_GL_ARB_texture_float;
-extern int GLAD_GL_EXT_framebuffer_object;
-extern int GLAD_GL_APPLE_vertex_array_object;
-
-typedef GLboolean (* PFNGLISRENDERBUFFEREXTPROC)(GLuint renderbuffer);
-extern PFNGLISRENDERBUFFEREXTPROC glad_glIsRenderbufferEXT;
-extern PFNGLISRENDERBUFFEREXTPROC glad_glIsRenderbuffer;
-
-typedef void (* PFNGLBINDRENDERBUFFEREXTPROC)(GLenum target, GLuint renderbuffer);
-extern PFNGLBINDRENDERBUFFEREXTPROC glad_glBindRenderbufferEXT;
-extern PFNGLBINDRENDERBUFFERPROC glad_glBindRenderbuffer;
-
-typedef void (* PFNGLDELETERENDERBUFFERSEXTPROC)(GLsizei n, const GLuint* renderbuffers);
-extern PFNGLDELETERENDERBUFFERSEXTPROC glad_glDeleteRenderbuffersEXT;
-extern PFNGLDELETERENDERBUFFERSEXTPROC glad_glDeleteRenderbuffers;
-
-
-typedef void (* PFNGLGENRENDERBUFFERSEXTPROC)(GLsizei n, GLuint* renderbuffers);
-extern PFNGLGENRENDERBUFFERSEXTPROC glad_glGenRenderbuffersEXT;
-extern PFNGLGENRENDERBUFFERSEXTPROC glad_glGenRenderbuffers;
-
-typedef void (* PFNGLRENDERBUFFERSTORAGEEXTPROC)(GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
-extern PFNGLRENDERBUFFERSTORAGEEXTPROC glad_glRenderbufferStorageEXT;
-extern PFNGLRENDERBUFFERSTORAGEEXTPROC glad_glRenderbufferStorage;
-
-typedef void (* PFNGLGETRENDERBUFFERPARAMETERIVEXTPROC)(GLenum target, GLenum pname, GLint* params);
-extern PFNGLGETRENDERBUFFERPARAMETERIVEXTPROC glad_glGetRenderbufferParameterivEXT;
-extern PFNGLGETRENDERBUFFERPARAMETERIVEXTPROC glad_glGetRenderbufferParameteriv;
-
-
-typedef void (* PFNGLBINDFRAMEBUFFEREXTPROC)(GLenum target, GLuint framebuffer);
-extern PFNGLBINDFRAMEBUFFEREXTPROC glad_glBindFramebufferEXT;
-extern PFNGLBINDFRAMEBUFFEREXTPROC glad_glBindFramebuffer;
-
-
-typedef GLboolean (* PFNGLISFRAMEBUFFEREXTPROC)(GLuint framebuffer);
-extern PFNGLISFRAMEBUFFEREXTPROC glad_glIsFramebufferEXT;
-extern PFNGLISFRAMEBUFFEREXTPROC glad_glIsFramebuffer;
-
-
-typedef void (* PFNGLDELETEFRAMEBUFFERSEXTPROC)(GLsizei n, const GLuint* framebuffers);
-extern PFNGLDELETEFRAMEBUFFERSEXTPROC glad_glDeleteFramebuffersEXT;
-extern PFNGLDELETEFRAMEBUFFERSEXTPROC glad_glDeleteFramebuffers;
-
-
-typedef void (* PFNGLGENFRAMEBUFFERSEXTPROC)(GLsizei n, GLuint* framebuffers);
-extern PFNGLGENFRAMEBUFFERSEXTPROC glad_glGenFramebuffersEXT;
-extern PFNGLGENFRAMEBUFFERSEXTPROC glad_glGenFramebuffers;
-
-
-typedef GLenum (* PFNGLCHECKFRAMEBUFFERSTATUSEXTPROC)(GLenum target);
-extern PFNGLCHECKFRAMEBUFFERSTATUSEXTPROC glad_glCheckFramebufferStatusEXT;
-extern PFNGLCHECKFRAMEBUFFERSTATUSEXTPROC glad_glCheckFramebufferStatus;
-
-
-typedef void (* PFNGLFRAMEBUFFERTEXTURE1DEXTPROC)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
-extern PFNGLFRAMEBUFFERTEXTURE1DEXTPROC glad_glFramebufferTexture1DEXT;
-extern PFNGLFRAMEBUFFERTEXTURE1DEXTPROC glad_glFramebufferTexture1D;
-
-
-typedef void (* PFNGLFRAMEBUFFERTEXTURE2DEXTPROC)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
-extern PFNGLFRAMEBUFFERTEXTURE2DEXTPROC glad_glFramebufferTexture2DEXT;
-extern PFNGLFRAMEBUFFERTEXTURE2DEXTPROC glad_glFramebufferTexture2D;
-
-
-typedef void (* PFNGLFRAMEBUFFERTEXTURE3DEXTPROC)(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLint zoffset);
-extern PFNGLFRAMEBUFFERTEXTURE3DEXTPROC glad_glFramebufferTexture3DEXT;
-extern PFNGLFRAMEBUFFERTEXTURE3DEXTPROC glad_glFramebufferTexture3D;
-
-
-typedef void (* PFNGLFRAMEBUFFERRENDERBUFFEREXTPROC)(GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer);
-extern PFNGLFRAMEBUFFERRENDERBUFFEREXTPROC glad_glFramebufferRenderbufferEXT;
-extern PFNGLFRAMEBUFFERRENDERBUFFEREXTPROC glad_glFramebufferRenderbuffer;
-
-
-typedef void (* PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVEXTPROC)(GLenum target, GLenum attachment, GLenum pname, GLint* params);
-extern PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVEXTPROC glad_glGetFramebufferAttachmentParameterivEXT;
-extern PFNGLGETFRAMEBUFFERATTACHMENTPARAMETERIVEXTPROC glad_glGetFramebufferAttachmentParameteriv;
-
-typedef void (* PFNGLGENERATEMIPMAPEXTPROC)(GLenum target);
-extern PFNGLGENERATEMIPMAPEXTPROC glad_glGenerateMipmapEXT;
-extern PFNGLGENERATEMIPMAPEXTPROC glad_glGenerateMipmap;
-
-typedef void (* PFNGLBINDVERTEXARRAYAPPLEPROC)(GLuint array);
-extern PFNGLBINDVERTEXARRAYAPPLEPROC glad_glBindVertexArrayAPPLE;
-extern PFNGLBINDVERTEXARRAYAPPLEPROC glad_glBindVertexArray;
-
-typedef void (* PFNGLDELETEVERTEXARRAYSAPPLEPROC)(GLsizei n, const GLuint* arrays);
-extern PFNGLDELETEVERTEXARRAYSAPPLEPROC glad_glDeleteVertexArraysAPPLE;
-extern PFNGLDELETEVERTEXARRAYSAPPLEPROC glad_glDeleteVertexArrays;
-
-typedef void (* PFNGLGENVERTEXARRAYSAPPLEPROC)(GLsizei n, GLuint* arrays);
-extern PFNGLGENVERTEXARRAYSAPPLEPROC glad_glGenVertexArraysAPPLE;
-extern PFNGLGENVERTEXARRAYSAPPLEPROC glad_glGenVertexArrays;
-
-typedef GLboolean (* PFNGLISVERTEXARRAYAPPLEPROC)(GLuint array);
-extern PFNGLISVERTEXARRAYAPPLEPROC glad_glIsVertexArrayAPPLE;
-extern PFNGLISVERTEXARRAYAPPLEPROC glad_glIsVertexArray;
-} // extern "C"
 
 namespace OFX {
 bool


### PR DESCRIPTION
gladLoadEGL() was not being consistently declared with C linkage which was leading to it being an undefined symbol in plugins like IO.ofx on Linux.

- Fixed header to apply extern "C" if the file is included by C++ code.
- Changed ofxsOGLUtilities.cc to include glad.h & gladegl.h instead of doing its own declarations of glad functions/types.
- Fixed a few declarations in ofsxOGLFunctions.h that did not match their counterparts in the glad headers.